### PR TITLE
Switched to Alt Buffer System

### DIFF
--- a/src/util/ansi.ts
+++ b/src/util/ansi.ts
@@ -13,6 +13,9 @@ export const CLEAR_SCREEN = '\x1b[2J\x1b[H';
 export const BOLD = '\x1b[1m';
 export const BEEP = '\x07';
 
+export const ALT_BUFFER_ON = '\x1b[?1049h';
+export const ALT_BUFFER_OFF = '\x1b[?1049l';
+
 export const nameToAnsi = (name: string): string => {
     switch (name.toLowerCase()) {
         case 'reset':
@@ -42,3 +45,4 @@ export const nameToAnsi = (name: string): string => {
             throw new Error(`Unknown ANSI color name: ${name}`);
     }
 };
+


### PR DESCRIPTION
### Feature: use ANSI Alt Buffer
Previously, upon finishing the game session, and scrolling up in the terminal, every _frame_ of the game (or rather terminal update) was visible, polluting the terminal despite the attempts at clearing it. 

The updated system now removes it from the main terminal view by pushing the intermediary output (i.e, excluding the final statistical output) to an alternative buffer, this is how programs like Vim and other full screen terminal applications operate. 

This commit has fixed the issue for me on Kitty, Alacritty, and the GNOME shell, however the issue is not fully finalized on **iTerm2** until the setting *Prefs > Profiles > Terminal > Save lines to scrollback in alternate screen mode* is switched off.

For more information on ANSI see [here](https://en.wikipedia.org/wiki/ANSI_escape_code#Control_Sequence_Introducer_commands)

---

> kindly comitted by @abb3v 